### PR TITLE
We don't build with versions prior to 1.21

### DIFF
--- a/images/capi/ansible/roles/containerd/templates/etc/containerd/config.toml
+++ b/images/capi/ansible/roles/containerd/templates/etc/containerd/config.toml
@@ -13,7 +13,6 @@ imports = ["/etc/containerd/conf.d/*.toml"]
     sandbox_image = "{{ pause_image }}"
   [plugins."io.containerd.grpc.v1.cri".registry]
     config_path = "/etc/containerd/certs.d"
-{% if kubernetes_semver is version('v1.21.0', '>=') %}
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
     runtime_type = "io.containerd.runc.v2"
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
@@ -37,7 +36,6 @@ imports = ["/etc/containerd/conf.d/*.toml"]
 {% if containerd_gvisor_runtime %}
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.gvisor]
     runtime_type = "io.containerd.runsc.v1"
-{% endif %}
 {% endif %}
 {% if packer_builder_type.startswith('azure') %}
   [plugins."io.containerd.grpc.v1.cri".registry.headers]


### PR DESCRIPTION

We are removing support for versions prior to 1.21 in the templates to simplify ongoing work