### PR TITLE
fix: Set default kubernetes version to 1.31.4 in the build AMI step

### DIFF
--- a/.github/workflows/image-ami-builds.yaml
+++ b/.github/workflows/image-ami-builds.yaml
@@ -5,8 +5,6 @@ on:
       branches:
          - main
          - ore/auth0_migration
-         - PLA-124-fix-kubeadm-errors
-
    workflow_dispatch:
       inputs:
          k8s_version:

--- a/.github/workflows/image-ami-builds.yaml
+++ b/.github/workflows/image-ami-builds.yaml
@@ -5,6 +5,7 @@ on:
       branches:
          - main
          - ore/auth0_migration
+         - PLA-124-fix-kubeadm-errors
 
    workflow_dispatch:
       inputs:
@@ -122,7 +123,7 @@ jobs:
       - name: Build AMI
         env:
           AWS_PROFILE: ditto-prod-primary
-          K8S_VERSION: ${{ github.event.inputs.k8s_version || '1.30.10' }}
+          K8S_VERSION: ${{ github.event.inputs.k8s_version || '1.31.4' }}
         run: |
           AWS_REGION=${{ env.AWS_REGION }} \
           ./images/capi/update_k8s_version.sh && \


### PR DESCRIPTION

This pull request updates the `.github/workflows/image-ami-builds.yaml` file to make adjustments to the workflow configuration and environment variables.
Environment variable updates:

* [`.github/workflows/image-ami-builds.yaml`](diffhunk://#diff-fadb18d0a02dedd940a9c9cc99dd9722fbbecb07f9b0e4d688274a3aa658d7d6L125-R124): Updated the default Kubernetes version (`K8S_VERSION`) from `1.30.10` to `1.31.4` in the `Build AMI` job.