### PR TITLE
PLA-93 Update GCP image k8s version

### DIFF
--- a/.github/workflows/image-ami-builds.yaml
+++ b/.github/workflows/image-ami-builds.yaml
@@ -169,7 +169,7 @@ jobs:
 
       - name: Build GCP Images
         env:
-          K8S_VERSION: ${{ github.event.inputs.k8s_version || '1.31.4' }}
+          K8S_VERSION: ${{ github.event.inputs.k8s_version || '1.32.4' }} 
           PKR_VAR_google_access_token: "${{ steps.gcp-auth.outputs.access_token }}"
         run: |
           ./images/capi/update_k8s_version.sh && \


### PR DESCRIPTION
This pull request updates the Kubernetes version used in the GCP image build process within the GitHub Actions workflow.

* [`.github/workflows/image-ami-builds.yaml`](diffhunk://#diff-fadb18d0a02dedd940a9c9cc99dd9722fbbecb07f9b0e4d688274a3aa658d7d6L172-R172): Updated the default Kubernetes version from `1.31.4` to `1.32.4` in the `Build GCP Images` job.