### PR TITLE
fix: disable AMI auto-publishing images as public

### DIFF
--- a/.github/workflows/image-ami-builds.yaml
+++ b/.github/workflows/image-ami-builds.yaml
@@ -19,7 +19,7 @@ on:
         description: "Include step to make AMIs public. Useful to disable when testing, so we don't pollute our public AMI list or bloat our quota limit."
         type: boolean
         required: false
-        default: true
+        default: false
 
 env:
   ARGOCD_ENDPOINTS: "argocd.ops.k8s.ditto.live"


### PR DESCRIPTION
During a recent commit on the trunk, we observed an outage for BentoBox's non production environment. This was a temporary outage triggered by this repo's GHA auto-publishing the new AMI publicly.

We had expected that the existing nodes would not roll, but found that CAPA was aggressively triggering AMI rolling updates. Due to the fact that AWS clusters on Valet use MachinePool and not MachineDeployment resources, the autoscaler is a little "out of touch" with the nodes.

AMI updating and the autoscaler caused a tough back and forth. To prevent unexpected issues like this we are going to default to not making the AMI public. Then we can choose when to dispatch the workflow for intentional releases.