### PR TITLE
feat: add CVE patch for sudo

### DIFF
--- a/images/capi/ansible/roles/node/tasks/dittoOverrides.yml
+++ b/images/capi/ansible/roles/node/tasks/dittoOverrides.yml
@@ -1,0 +1,6 @@
+---
+- name: Install latest sudo package for requested CVE patches
+  apt:
+    name: sudo
+    state: latest
+    update_cache: true

--- a/images/capi/ansible/roles/node/tasks/main.yml
+++ b/images/capi/ansible/roles/node/tasks/main.yml
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-- ansible.builtin.import_tasks: photon.yml
-  when: ansible_os_family == "VMware Photon OS"
+- ansible.builtin.import_tasks: dittoOverrides.yml
 
 - ansible.builtin.import_tasks: amazonLinux.yml
   when: ansible_distribution == "Amazon"
+
+- ansible.builtin.import_tasks: photon.yml
+  when: ansible_os_family == "VMware Photon OS"
 
 # This is required until https://github.com/ansible/ansible/issues/77537 is fixed and used.
 - name: Override Flatcar's OS family


### PR DESCRIPTION
Bento Box has highlighted a CVE with `sudo` that was recently fixed on the main repository in Ubuntu. This change adds an Ansible task to force sudo to update during the AMI build.

X-Ticket-Id: PLA-204