### PR TITLE
fix: post flatcar build fixes

### DIFF
--- a/.github/workflows/image-ami-builds.yaml
+++ b/.github/workflows/image-ami-builds.yaml
@@ -6,7 +6,6 @@ on:
       - main
       - ore/auth0_migration
       - vignesh/fix-k8s-version
-      - ditt/enable-flatcar-builds
   workflow_dispatch:
     inputs:
       k8s_version:

--- a/images/capi/packer/ami/flatcar-arm64.json
+++ b/images/capi/packer/ami/flatcar-arm64.json
@@ -17,6 +17,7 @@
   "kubernetes_goarch": "arm64",
   "kubernetes_source_type": "http",
   "python_path": "/opt/bin/builder-env/site-packages",
+  "manifest_output": "packer-manifest.json",
   "root_device_name": "/dev/xvda",
   "snapshot_groups": "",
   "ssh_username": "core",

--- a/images/capi/packer/ami/flatcar.json
+++ b/images/capi/packer/ami/flatcar.json
@@ -13,6 +13,7 @@
   "kubernetes_source_type": "http",
   "compliance_playbook": "./ansible/playbooks/noop.yml",
   "python_path": "/opt/bin/builder-env/site-packages",
+  "manifest_output": "packer-manifest.json",
   "root_device_name": "/dev/xvda",
   "snapshot_groups": "",
   "ssh_username": "core",

--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -252,7 +252,6 @@
     "volume_size": "8",
     "volume_type": "gp3",
     "vpc_id": "",
-    "oscap_file": "{{env `oscap_file`}}",
-    "compliance_playbook": "./ansible/playbooks/noop.yml"
+    "oscap_file": "{{env `oscap_file`}}"
   }
 }

--- a/images/capi/packer/ami/ubuntu-2404.json
+++ b/images/capi/packer/ami/ubuntu-2404.json
@@ -18,5 +18,5 @@
   "ami_regions": "eu-west-3,eu-west-2,eu-west-1,ca-central-1,eu-central-1,us-east-1,us-east-2,us-west-1,us-west-2,ap-southeast-2",
   "manifest_output": "packer-manifest.json",
   "oscap_file": "scap-security-guide-0.1.76",
-  "patched_playbook": "/opt/ssg/scap-security-guide-0.1.76/ansible/ubuntu2404-playbook-cis_level1_server.yml"
+  "compliance_playbook": "/opt/ssg/scap-security-guide-0.1.76/ansible/ubuntu2404-playbook-cis_level1_server.yml"
 }


### PR DESCRIPTION
Minor fixes for items broken or incomplete in #20 

**Packer Configuration Enhancements:**

* Added the `manifest_output` variable (set to `packer-manifest.json`) to both `flatcar-arm64.json` and `flatcar.json` Packer templates, which is required by the optional workflow step to make the AMI public. [[1]](diffhunk://#diff-4ac436d77fa58590e6a7231d9aa202a45a019f84102351c77c55e4d359d817c2R20) [[2]](diffhunk://#diff-61fb0654fc8e43fe9e2b7c28534e3ab6b0ef593e0481581e07f5e48052346db4R16)

**Variable Name Standardization and Cleanup:**

* In `ubuntu-2404.json`, replaced the `patched_playbook` variable with `compliance_playbook` for consistency with other templates.
* In `packer.json`, removed the `compliance_playbook` variable from the variables list, possibly to avoid redundancy or because it's no longer needed in this base template.

This was to fix the OSCAP compliance playbook not being run for AWS Ubuntu builds. 

NOTE - the Ubuntu builds are currently broken. 
There seems to be some change in recent ubuntu packes that break the OSCAP compliance playbook. We are moving away from Ubuntu so I'm going to punt on trying to fix that right now. 