### PR TITLE
fix: update k8s version for flatcar arm64 builds

### DIFF
--- a/.github/workflows/image-ami-builds.yaml
+++ b/.github/workflows/image-ami-builds.yaml
@@ -190,6 +190,7 @@ jobs:
           AWS_PROFILE: ditto-prod-primary
           K8S_VERSION: ${{ github.event.inputs.k8s_version }}
           TARGET_OS: flatcar
+          TARGET_ARCH: ${{ matrix.arch }}
         run: |
           ./images/capi/update_k8s_version.sh && \
           if [ "${{ matrix.arch }}" = "amd64" ]; then

--- a/images/capi/update_k8s_version.sh
+++ b/images/capi/update_k8s_version.sh
@@ -3,8 +3,9 @@
 set -euo pipefail
 
 CLOUD="${CLOUD:-aws}"
-K8S_VERSION="${K8S_VERSION:-1.31.4}"
+K8S_VERSION="${K8S_VERSION:-1.31.13}"
 TARGET_OS="${TARGET_OS:-ubuntu-2404}"
+TARGET_ARCH="${TARGET_ARCH:-amd64}"
 
 # Extract kubernetes series from version (e.g., "1.30.10" -> "v1.30")
 K8S_SERIES="v$(echo "$K8S_VERSION" | cut -d. -f1,2)"
@@ -31,7 +32,12 @@ echo "  crictl_version: $CRICTL_VERSION"
 case "$CLOUD" in
   aws)
     # AWS-specific block to update AWS packer file
-    AWS_FILE=$(find ./images/capi/packer/ami -name "${TARGET_OS}.json" | head -n 1)
+    if [ "$TARGET_ARCH" = "arm64" ] && [ "$TARGET_OS" = "flatcar" ]; then
+      # special case for flatcar arm64
+      AWS_FILE=$(find ./images/capi/packer/ami -name "${TARGET_OS}-arm64.json" | head -n 1)
+    else
+      AWS_FILE=$(find ./images/capi/packer/ami -name "${TARGET_OS}.json" | head -n 1)
+    fi
 
     if [ -z "$AWS_FILE" ]; then
         echo "Error: ${TARGET_OS}.json file could not be found."


### PR DESCRIPTION
This pull request updates the Kubernetes image build process to support specifying the target architecture and to handle special cases for Flatcar ARM64 builds. It also bumps the default Kubernetes version and improves flexibility in the build scripts.

**Build process improvements:**

* Added support for specifying the `TARGET_ARCH` environment variable in both the GitHub Actions workflow (`.github/workflows/image-ami-builds.yaml`) and the build script (`images/capi/update_k8s_version.sh`). This enables building images for different architectures, such as `amd64` and `arm64`. [[1]](diffhunk://#diff-fadb18d0a02dedd940a9c9cc99dd9722fbbecb07f9b0e4d688274a3aa658d7d6R193) [[2]](diffhunk://#diff-333110abcaf513bfa47c45c21d7b0cc3c21f4129fea081b7610f94649b7ed21dL6-R8)
* Updated the script logic to handle a special case for Flatcar on ARM64 by selecting the correct Packer template file (`flatcar-arm64.json`) when building for this combination.

**Version update:**

* Bumped the default Kubernetes version from `1.31.4` to `1.31.13` in the build script (`images/capi/update_k8s_version.sh`).